### PR TITLE
Gzip race condition / Consume typo

### DIFF
--- a/plugins/dest/consumeKinesis.go
+++ b/plugins/dest/consumeKinesis.go
@@ -96,7 +96,7 @@ func (g destpluginInterface) Initialize(args ...interface{}) (result interface{}
 		return nil, err
 	}
 
-	if strings.EqualFold(strings.TrimSpace(splits[4]), "true") {
+	if strings.EqualFold(strings.TrimSpace(splits[5]), "true") {
 		err = k.CreateRequiredTables()
 		if err != nil {
 			log.WithFields(logrus.Fields{

--- a/s3Batcher/s3bufferclient.go
+++ b/s3Batcher/s3bufferclient.go
@@ -119,7 +119,7 @@ func (s *S3BufferClient) Init() {
 	// begin batching
 }
 
-
+func NewBufferClient(Env string, Shard_Id string, S3_Bucket string, Region string, Flush_Interval int64, MAX_BUFFER_SIZE int64, Config string, metricSender *metrics.MetricSender) (*S3BufferClient, error) {
 
 	BufferClient := &S3BufferClient{
 		Env:             Env,


### PR DESCRIPTION
Fixes the gzip race condition - when gzip was running a potential record could come in and attempt to write to the file. 

Fixes the consume kinesis plugin where the argument was incorrectly indexed