### PR TITLE
readme. grammar edits.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 Anthony Merrill (cb-anthony-merrill), David Patawaran (dpat-cb), Jeremy Kelley (nod), Michael Xiao (mxiao-cb), Xavier Thierry (cb-xav)
 
 ### Purpose
-The Event Query Router (EQR) was a solution to Carbon Black’s need to provide data quickly to internal stakeholders such as Threat Research, Threat Analysis Unit (TAU) and Analytics. Current solutions require adding business logic to predefined programs written in other languages like Python and Scala. This means that adding or changing destinations, fields require a developer to add the code, test, verify and deploy manually. The manual process does not provide Carbon Black’s internal stakeholders the rapid delivery they require to be successful. 
+The Event Query Router (EQR) was a solution to Carbon Black’s need to provide data quickly to internal stakeholders such as Threat Research, Threat Analysis Unit (TAU) and Analytics. Current solutions require adding business logic to predefined programs written in other languages like Python and Scala. This means that adding or changing destinations, fields require a developer to add the code, test, verify and deploy manually. The manual process does not provide Carbon Black’s internal stakeholders the rapid delivery they require to be successful.
 
 The solution, EQR, allows teams providing the manual service, relief in terms of having to provide ad hoc services to other stakeholders. It also provides these stakeholders the ability to write simple logic in a defined language by EQR to get the data they require quickly and delivered at the endpoint and in the format they need. The language is part of two foundational pieces that make up EQR: EQRLang and the Plugin System and does not require prior knowledge of other programming languages, build and large deployment processes.
 
@@ -19,9 +19,9 @@ Below is a visual of a typical EQR Application Workflow
 ![alt text](https://github.com/carbonblack/eqr/blob/master/docs/images/EQRWorkflow.png "EQR Application Workflow")
 
 
-The first step when EQR starts up is pulls the necessary Rulesets, Rules, and Plugins from an S3 bucket supplied by the developer. The files are then downloaded stored, and Plugins are built at runtime. 
+The first step when EQR starts up is pulls the necessary Rulesets, Rules, and Plugins from an S3 bucket supplied by the developer. The files are then downloaded stored, and Plugins are built at runtime.
 
-EQR will then take the rules are run them through the EQRLang processor where rules will be broken down into their Destination, Predicate, and Projection components. See EQRLang for further explanation. 
+EQR will then take the rules are run them through the EQRLang processor where rules will be broken down into their Destination, Predicate, and Projection components. See EQRLang for further explanation.
 
 When EQR has successfully built the rules, the defined consuming rule will then begin to process. Assuming we are consuming from a Kinesis stream, each record that is pulled from the shard(s) is then sent to the EQRLang processor and run through the built rules. If a record matches the Predicate defined the rule, the Projection process begins which will translate the data as defined and send to the final destination.
 
@@ -29,13 +29,13 @@ When EQR has successfully built the rules, the defined consuming rule will then 
 Rulesets are a group of rules that an EQR worker will need to perform. The rulesets are defined in JSON and contain a limited amount of information, enough for EQR to download and setup rules. There are three requirements for a Ruleset.
 
 1. Rulesets must have a 'RuleName' defined.
- 
+
     *It is assumed and appropriate the filename is the RuleName.*
 
-2. Rulesets must have a 'RecordGenerator' rule defined. 
+2. Rulesets must have a 'RecordGenerator' rule defined.
 
     *This rule is responsible for pulling records from a source, this record will be sent to the rules.*
-    
+
 3. Rulesets must have at minimum one 'RecordRules' defined.
 
     *A JSON array must be provided. The rules contain the Predicate, Projection and Destination information.*
@@ -59,7 +59,7 @@ CONSUME.MONGO_TEST_PLUGIN[]({},{})
 
 The Rule above tells EQR that we are going to be consuming from a MongoDB, specifically a plugin that we've written called 'MONGO_TEST_PLUGIN'. The data that comes from this Plugin will be utilized as the record to send to other rules. For this example, lets assume the plugin mentioned above returns a JSON string.
 
-Lets say a resulting record from the plugin looks like the following: 
+Lets say a resulting record from the plugin looks like the following:
 
 ```json
 {
@@ -89,7 +89,7 @@ S3.BATCH[...parameters...](
 
 The Rule above does a few things. It defines that the destination is going to utilize the Batching plugin to S3 that comes as part of the EQR Language. The Predicate tells us, that whatever record is coming through on this rule has to have a JSON key of 'SomeKey' and it cannot be null. If a record comes through and has a JSON value with they key 'SomeKey' we will send ALL contents of the record to the destination.
 
-Rules however, can be more complex. Depending on the data and translation someone wants an EQR rule can easily do the translation with a variety of plugins and functions that are easily extensible. 
+Rules however, can be more complex. Depending on the data and translation someone wants an EQR rule can easily do the translation with a variety of plugins and functions that are easily extensible.
 
 Assuming we are still getting JSON data, we could specify a rule like the following.
 
@@ -118,12 +118,12 @@ The rule would take the record coming from the Consume MongoDB plugin and match 
 }
 ```
 
-EQR Provides a way to be both compact and verbose for translating data at real-time. It allows users to write smaller, simpler and easier rules for doing data translations. 
+EQR Provides a way to be both compact and verbose for translating data at real-time. It allows users to write smaller, simpler and easier rules for doing data translations.
 
 ###EQRLang
-The EQR Language is an extensible plugin system. The rules are built around the three requirements of Predicate, Projection, (Consumption/Destination). Operators, Functions and the way consuming and sending data to the final destination are exposed plugins that can be extended. 
+The EQR Language is an extensible plugin system. The rules are built around the three requirements of Predicate, Projection, (Consumption/Destination). Operators, Functions and the way consuming and sending data to the final destination are exposed plugins that can be extended.
 
-EQR supports the current `operators` out-of-the-box. *Note* these are for Predicate lines only. 
+EQR supports the current `operators` out-of-the-box. *Note* these are for Predicate lines only.
 
 | Operator | Returns      |
 | :------: | :-----------:|
@@ -147,7 +147,7 @@ EMIT.KINESIS[myKinesisStream,  ]({
 	})
 ```
 
-EQR supports the following `functions` out-of-the-box. *Note* For Projection lines the keyword `AS`is available, this instructs EQR to use the name to right of `AS` for the name of key being sent downstream. If you leave off the `AS` keyword, EQR will by default use the keyname from the data that it is parsing.
+EQR supports the following `functions` out-of-the-box. *Note* For Projection lines the keyword `AS` is available, this instructs EQR to use the name to right of `AS` for the name of key being sent downstream. If you leave off the `AS` keyword, EQR will by default use the keyname from the data that it is parsing.
 
 | Function | Parameter(s) | Return Value |
 | :------: | :----------: | :-----: |
@@ -169,7 +169,7 @@ EQR Supports the current Consumers / Destination Plugins out-of-the-box.
 | Name  | Parameters | Notes |
 | :---: | :-------:  | :---: |
 | CONSUME.KINESIS | `(KinesisStreamName, Region, ConsumerName, RoleToConsume, ConsumerARNvalue, CreateDynamoTable[True/False])` | Uses enhanced fanout, rules are per-shard (cross shard coming-soon) |
-| EMIT.KINESIS | `(StreamName, Role[Optional])` | Emits data to Kinesis stream| 
+| EMIT.KINESIS | `(StreamName, Role[Optional])` | Emits data to Kinesis stream|
 | S3.BATCH | `(Environment, ShardID, S3Bucket, Region, FlushInterval[seconds], BufferSize[bytes])`|Batches data until the FlushInterval or Buffersize is hit|
 
 ### Getting Started
@@ -211,12 +211,13 @@ CMD /go/src/app/app exampleRuleset ./config/example.json
   AWS_SECRET_ACCESS_KEY
   AWS_REGION
 ```
-2. By default the tests look for a dynamodb server at localhost:4567 and kinesis server at localhost:4568. Can install kinesalite and dynalite using npm.
+
+2. By default the tests look for a dynamodb server at localhost:4567 and kinesis server at localhost:4568. Install kinesalite and dynalite using npm.
 ```bash
 kinesalite --port 4568 --createStreamMs 1 --deleteStreamMs 1 --updateStreamMs 1 --shardLimit 1000 &
 dynalite --port 4567 --createTableMs 1 --deleteTableMs 1 --updateTableMs 1 &
 ```
-3. run `make test`
+3. Run `make test`
 
 ### Contributing to EQR
 To contribute to EQR:


### PR DESCRIPTION
My editor removed the trailing spaces so it looks like I made more edits than I really did.

Changes included, 

- "EQR supports the following `functions` out-of-the-box. *Note* For Projection lines the keyword `AS`is available, ... " -> "EQR supports the following `functions` out-of-the-box. *Note* For Projection lines the keyword `AS` is available, "


- "3. run `make test`" -> "3. Run `make test`"
